### PR TITLE
Throw unauthenticated error only for private endpoints

### DIFF
--- a/con.js
+++ b/con.js
@@ -228,8 +228,10 @@ class Connection extends EventEmitter {
       await this.afterReconnect();
     }
 
-    if(!this.authenticated) {
-      throw new Error('Not authenticated.');
+    if (path.startsWith('private')) {
+      if(!this.authenticated) {
+        throw new Error('Not authenticated.');
+      }
     }
 
     const message = {


### PR DESCRIPTION
As public endpoints are openly accessible, there is no reason to throw a "not authenticated" exception if requesting data from a public endpoint - even when `null` API keys have been provided